### PR TITLE
fix: File not truncated before writting

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -102,7 +102,12 @@ func ExecuteTextAction(action Action, r io.Reader, w util.OffsetWriter, repoName
 
 	outputData, msg := actionFn(action, regex, fileData)
 
-	_, err = w.WriteAt([]byte(outputData), 0)
+	err = w.Truncate(0)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to truncate file %s", action.Path)
+	}
+
+	_, err = w.WriteAt(outputData, 0)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to write file %s", action.Path)
 	}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -27,8 +27,12 @@ func mockFile(contents string) (*strings.Reader, *MockWriter) {
 	return r, mw
 }
 
+func (mw *MockWriter) Truncate(size int64) error {
+	mw.w.Truncate(int(size))
+	return nil
+}
+
 func (mw *MockWriter) WriteAt(b []byte, off int64) (n int, err error) {
-	mw.w.Truncate(int(off))
 	return mw.w.Write(b)
 }
 

--- a/main.go
+++ b/main.go
@@ -234,6 +234,7 @@ func main() {
 			results, err := performActions(conf.Actions, repo)
 			if err != nil {
 				failedCh <- err
+				return
 			}
 
 			lock.Lock()

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,6 @@
 package util
 
 type OffsetWriter interface {
+	Truncate(size int64) error
 	WriteAt(b []byte, off int64) (n int, err error)
 }


### PR DESCRIPTION
Fixes bug where the file was not truncated before being written to when performing text actions. This would cause extra garbage to show up at the end if the file was smaller than it was originally after performing the action.

Ex:
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/22629536/74394634-185ac580-4ddb-11ea-9938-9d7821fda106.png">
