### PR TITLE
feat!: Change action config to be clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,187 @@
 # Commit Cannon
 
-cannon is a small CLI tool that lets you make changes to multiple git repos.
+`cannon` is a small CLI tool that lets you make changes to multiple git repos.
 
 ![](docs/resources/cannon.gif)
 
 ## Why?
+
 Suppose you need to make the same change across multiple git repos.
 You could do it all by hand but this will get quite tedious especially with the more repos you have. Automation to the rescue!
 
-cannon makes it easy to perform a batch of changes on multiple git repos at once. It even creates GitHub PRs by default.
+`cannon` makes it easy to perform a batch of changes on multiple git repos at once. It even creates GitHub PRs by default.
 All the heavy lifting is taken care of giving you time to do more important things.
 
 If you want to know more about why we did this and see a use case for it checkout out our [blog post](https://medium.com/touchbistro-development/commit-cannon-open-source-project-899ee75794c0).
 
 ## Setup Instructions
 
-1. Make sure you have go installed and set up.
-2. Clone the repo:
-    ```sh
-    git clone git@github.com:touchbistro/cannon.git
-    ```
-3. Compile and install cannon globally:
-    ```sh
-    go install
-    ```
+1. Make sure you have [Go](https://golang.org/doc/install) installed and set up.
+2. Install `cannon`:
 
-    **NOTE:** Make sure you have the following in your `~/.bash_profile` or `~/.zshrc` to ensure programs installed with `go install` are available globally:
-    ```sh
-    export PATH="$(go env GOPATH)/bin:$PATH"
-    ```
-4. Create a GitHub Access Token
-    - Create the token with the `repo` box checked in the list of permissions. Follow the instructions [here](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to learn more.
-        - Make sure you copy the token when you create it!
-    - After the token has been created, enable SSO for it.
-    - Add the following to your `.bash_profile` or `.zshrc`:
-    ```sh
-    export HOMEBREW_GITHUB_API_TOKEN=<YOUR_TOKEN>
-    ```
-    - Run `source ~/.zshrc` or `source ~/.bash_profile`.
+   ```sh
+   go install github.com/TouchBistro/cannon@latest
+   ```
+
+   **NOTE:** Make sure you have the following in your `~/.bash_profile` or `~/.zshrc` to ensure programs installed with `go install` are available globally:
+
+   ```sh
+   export PATH="$(go env GOPATH)/bin:$PATH"
+   ```
+
+3. Create a GitHub Access Token:
+
+   A Github Access Token is required to be able create GitHub PRs for changes to repos.
+
+   - Create the token with the `repo` box checked in the list of permissions. Follow the instructions [here](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to learn more.
+   - Set the `GITHUB_TOKEN` environment variable to the value of the token.
+     For example if you use bash or zsh, add the following to your `.bash_profile` or `.zshrc`:
+
+     ```sh
+     export GITHUB_TOKEN=<YOUR_TOKEN>
+     ```
 
 ## Usage
-To use cannon provide a `cannon.yml` file which contains a list of repos and a list of actions to apply.
+
+To use `cannon` provide a `cannon.yml` file which contains a list of repos and a list of actions to apply.
 
 ```sh
 Usage of ./cannon:
-  -m, --commit-message string   The commit message to use
+      --clean                   Clean cannon cache directory
+  -m, --commit-message string   The commit message to use (default "Apply commit-cannon changes")
       --no-pr                   Prevents creating a Pull Request in the remote repo
       --no-push                 Prevents pushing to remote repo
   -p, --path string             The path to a cannon.yml config file (default "cannon.yml")
+  -v, --verbose                 Enable verbose logging
 ```
 
-cannon supports the following actions:
-1. replaceLine - Replace an entire line including any leading whitespace at specified path (trims trailing whitespace).
-    ```yml
-    type: replaceLine
-    source: <The line to add>
-    target: <The line that will be replaced>
-    path: <The path to the file>
-    ```
-2. deleteLine - Delete an entire line including any leading whitespace at the specified path.
-    ```yml
-    type: deleteLine
-    target: <The line to delete>
-    path: <The path to the file>
-    ```
-3. replaceText - Replace some text at specified path.
-    ```yml
-    type: replaceText
-    source: <The text to add>
-    target: <The text that will be replaced>
-    path: <The path to the file>
-    ```
-4. appendText - Append text to matching text.
-    ```yml
-    type: appendText
-    source: <The text to append>
-    target: <The text that will be appended to>
-    path: <The path to the file>
-    ```
-5. createFile - Create file at specified path if it doesn't already exist.
-    ```yml
-    type: createFile
-    source: <The file to use>
-    path: <The path to create the file at>
-    ```
-6. deleteFile - Delete file at specified path if it already exists.
-    ```yml
-    type: deleteFile
-    path: <The path to the file to delete>
-    ```
-7. replaceFile - Replace file at specified path if it already exists.
-    ```yml
-    type: replaceFile
-    source: <The file to use>
-    path: <The path to the file to replace>
-    ```
-8. createOrReplaceFile - Create or replace file at specified path.
-    ```yml
-    type: createOrReplaceFile
-    source: <The file to use>
-    path: <The path to create or replace the file at>
-    ```
-9. runCommand - Runs a given shell command in the repo.
-    ```yml
-    type: runCommand
-    run: <The shell command to run>
-    ```
-    You can also run shell (`sh`) commands by prefixing the command with `SHELL >>`.
-    Ex:
-    ```yml
-    type: runCommand
-    run: SHELL >> if [[ ! -d data ]]; then mkdir data; touch data/.gitkeep; fi
-    ```
+### Actions
+
+`cannon` supports 3 categories of actions which are described below.
+
+#### Text Actions
+
+A text action is an action applied to the text in a file within a repo.
+The search text for the action is a regex which allows for complex searches within a file.
+The `path` field in the config must be relative to the root of the repo.
+
+The following text actions are supported:
+
+1. `replaceLine` - Replace an entire line including any leading whitespace (trims trailing whitespace).
+   ```yml
+   type: replaceLine
+   searchText: <The line that will be replaced>
+   applyText: <The line to add>
+   path: <The path to the file>
+   ```
+2. `deleteLine` - Delete an entire line including any leading whitespace.
+   ```yml
+   type: deleteLine
+   searchText: <The line to delete>
+   path: <The path to the file>
+   ```
+3. `replaceText` - Replace some text. The text can span multiple lines.
+   ```yml
+   type: replaceText
+   searchText: <The text that will be replaced>
+   applyText: <The text to add>
+   path: <The path to the file>
+   ```
+4. `appendText` - Append text to matching text.
+   ```yml
+   type: appendText
+   searchText: <The text that will be appended to>
+   applyText: <The text to append>
+   path: <The path to the file>
+   ```
+5. `deleteText` - Delete matching text. The text can span multiple lines.
+   ```yml
+   type: deleteText
+   searchText: <The text to delete>
+   path: <The path to the file>
+   ```
+
+#### File Actions
+
+A file action is an action applied to an entire file within a repo.
+The `dstPath` field in the config must be relative to the root of the repo.
+
+The following file actions are supported:
+
+1. `createFile` - Create a file if it doesn't already exist.
+   ```yml
+   type: createFile
+   srcPath: <The file to use>
+   dstPath: <The path to create the file at>
+   ```
+2. `replaceFile` - Replace a file if it already exists.
+   ```yml
+   type: replaceFile
+   srcPath: <The file to use>
+   dstPath: <The path to the file to replace>
+   ```
+3. `createOrReplaceFile` - Create a file if it doesn't exist or replace it if it does exist.
+   ```yml
+   type: createOrReplaceFile
+   srcPath: <The file to use>
+   dstPath: <The path to create or replace the file at>
+   ```
+4. `deleteFile` - Delete a file if it already exists.
+   ```yml
+   type: deleteFile
+   dstPath: <The path to the file to delete>
+   ```
+
+#### Command Action
+
+A command action allows for running a command in a repo.
+
+The following command actions are supported:
+
+1. `runCommand` - Runs a command in the repo.
+   ```yml
+   type: runCommand
+   run: <The command to run>
+   ```
+2. `shellCommand` - Runs a command in a shell (`sh`) in a repo.
+   ```yml
+   type: shellCommand
+   run: <The shell command to run>
+   ```
 
 ## Configuration
 
 `cannon.yml` example:
 The `cannon.yml` file is structured as follows:
+
 ```yml
 repos:
   - name: TouchBistro/touchbistro-node-boilerplate
   - name: TouchBistro/touchbistro-node-shared
 actions:
   - type: replaceLine
-    source: DB_USER=core
-    target: DB_USER=SA
+    searchText: DB_USER=SA
+    applyText: DB_USER=core
     path: .env.example
   - type: replaceText
-    source: LOGGER.debug
-    target: console.log
+    searchText: console.log
+    applyText: LOGGER.debug
     path: src/index.ts
   - type: createFile
-    source: files/text.txt
-    path: text.txt
+    srcPath: files/text.txt
+    dstPath: text.txt
   - type: deleteFile
-    path: .env.example
+    dstPath: .env.example
   - type: replaceFile
-    source: files/.env.test
-    path: .env.compose
+    srcPath: files/.env.test
+    dstPath: .env.compose
   - type: createOrReplaceFile
-    source: files/.env.test
-    path: .env.test
+    srcPath: files/.env.test
+    dstPath: .env.test
   - type: runCommand
-    run: yarn
+    run: yarn install
+  - type: shellCommand
+    run: if [ ! -d data ]; then mkdir data; touch data/.gitkeep; fi
 ```
 
 ### Change base branch for PRs
@@ -151,9 +190,10 @@ By default `cannon` will target `master` as the base branch when creating PRs.
 If you need to use a different base branch you can set it using the `base` field of the repo.
 
 Example:
+
 ```yml
 repos:
-  - name: TouchBistro/repo-name
+  - name: org/repo-name
     base: develop
 ```
 

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -35,10 +35,10 @@ func TestTextAction(t *testing.T) {
 			name: "replace line",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "replaceLine",
-				Source: "# WOKE ZONE",
-				Target: "# HYPE ZONE",
-				Path:   "replace_line.md",
+				Type:       "replaceLine",
+				ApplyText:  "# WOKE ZONE",
+				SearchText: "# HYPE ZONE",
+				Path:       "replace_line.md",
 			},
 			wantMsg: "Replaced line `# HYPE ZONE` with `# WOKE ZONE` in `replace_line.md`",
 			out: `# WOKE ZONE
@@ -52,9 +52,9 @@ This section is pretty hype.
 			name: "delete line",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "deleteLine",
-				Target: "## Hype Section",
-				Path:   "delete_line.md",
+				Type:       "deleteLine",
+				SearchText: "## Hype Section",
+				Path:       "delete_line.md",
 			},
 			wantMsg: "Deleted line `## Hype Section` in `delete_line.md`",
 			out: `# HYPE ZONE
@@ -67,10 +67,10 @@ This section is pretty hype.
 			name: "replace text",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "replaceText",
-				Source: "*****",
-				Target: "^#.+",
-				Path:   "replace_text.md",
+				Type:       "replaceText",
+				ApplyText:  "*****",
+				SearchText: "^#.+",
+				Path:       "replace_text.md",
 			},
 			wantMsg: "Replaced text `^#.+` with `*****` in `replace_text.md`",
 			out: `*****
@@ -84,10 +84,10 @@ This section is pretty hype.
 			name: "append text",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "appendText",
-				Source: " --- ${REPO_OWNER} - ${REPO_NAME}",
-				Target: "^#.+",
-				Path:   "append_text.md",
+				Type:       "appendText",
+				ApplyText:  " --- ${REPO_OWNER} - ${REPO_NAME}",
+				SearchText: "^#.+",
+				Path:       "append_text.md",
 			},
 			vars: map[string]string{
 				"REPO_OWNER": "TouchBistro",
@@ -105,9 +105,9 @@ This section is pretty hype.
 			name: "delete text",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "deleteText",
-				Target: `\**hype\**`,
-				Path:   "delete_text.txt",
+				Type:       "deleteText",
+				SearchText: `\**hype\**`,
+				Path:       "delete_text.txt",
 			},
 			wantMsg: "Deleted all occurrences of `\\**hype\\**` in `delete_text.txt`",
 			out: `# HYPE ZONE
@@ -163,10 +163,10 @@ func TestTextActionError(t *testing.T) {
 			name: "invalid regex",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "replaceText",
-				Source: "noop",
-				Target: "($*^",
-				Path:   "invalid_regex.md",
+				Type:       "replaceText",
+				ApplyText:  "noop",
+				SearchText: "($*^",
+				Path:       "invalid_regex.md",
 			},
 		},
 	}
@@ -207,9 +207,9 @@ func TestFileAction(t *testing.T) {
 			name: "create file",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "createFile",
-				Source: filepath.Join(sd, "create_file.md"),
-				Path:   "create_file.md",
+				Type:    "createFile",
+				SrcPath: filepath.Join(sd, "create_file.md"),
+				DstPath: "create_file.md",
 			},
 			wantMsg: "Created file `create_file.md`",
 			out:     inputText,
@@ -219,9 +219,9 @@ func TestFileAction(t *testing.T) {
 			in:       inputText,
 			existing: `content goes here`,
 			cfg: action.Config{
-				Type:   "replaceFile",
-				Source: filepath.Join(sd, "replace_file.md"),
-				Path:   "replace_file.md",
+				Type:    "replaceFile",
+				SrcPath: filepath.Join(sd, "replace_file.md"),
+				DstPath: "replace_file.md",
 			},
 			wantMsg: "Replaced file `replace_file.md`",
 			out:     inputText,
@@ -230,9 +230,9 @@ func TestFileAction(t *testing.T) {
 			name: "createOrReplace missing file",
 			in:   inputText,
 			cfg: action.Config{
-				Type:   "createOrReplaceFile",
-				Source: filepath.Join(sd, "replace_missing_file.md"),
-				Path:   "replace_missing_file.md",
+				Type:    "createOrReplaceFile",
+				SrcPath: filepath.Join(sd, "replace_missing_file.md"),
+				DstPath: "replace_missing_file.md",
 			},
 			wantMsg: "Created file `replace_missing_file.md`",
 			out:     inputText,
@@ -242,9 +242,9 @@ func TestFileAction(t *testing.T) {
 			in:       inputText,
 			existing: `content goes here`,
 			cfg: action.Config{
-				Type:   "createOrReplaceFile",
-				Source: filepath.Join(sd, "replace_existing_file.md"),
-				Path:   "replace_existing_file.md",
+				Type:    "createOrReplaceFile",
+				SrcPath: filepath.Join(sd, "replace_existing_file.md"),
+				DstPath: "replace_existing_file.md",
 			},
 			wantMsg: "Replaced file `replace_existing_file.md`",
 			out:     inputText,
@@ -253,8 +253,8 @@ func TestFileAction(t *testing.T) {
 			name:     "delete file",
 			existing: `content goes here`,
 			cfg: action.Config{
-				Type: "deleteFile",
-				Path: "delete_file.md",
+				Type:    "deleteFile",
+				DstPath: "delete_file.md",
 			},
 			wantMsg: "Deleted file `delete_file.md`",
 		},
@@ -265,12 +265,12 @@ func TestFileAction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create source file
 			if tt.in != "" {
-				if err := os.WriteFile(tt.cfg.Source, []byte(tt.in), os.ModePerm); err != nil {
+				if err := os.WriteFile(tt.cfg.SrcPath, []byte(tt.in), os.ModePerm); err != nil {
 					t.Fatalf("failed to write file: %v", err)
 				}
 			}
 			// Create existing target file
-			path := filepath.Join(td, tt.cfg.Path)
+			path := filepath.Join(td, tt.cfg.DstPath)
 			if tt.existing != "" {
 				if err := os.WriteFile(path, []byte(tt.existing), os.ModePerm); err != nil {
 					t.Fatalf("failed to write file: %v", err)
@@ -319,10 +319,10 @@ func TestParseError(t *testing.T) {
 		{
 			name: "invalid text action",
 			cfg: action.Config{
-				Type:   "garlicText",
-				Source: "noop",
-				Target: "noop",
-				Path:   "noop.md",
+				Type:    "garlicText",
+				SrcPath: "noop",
+				DstPath: "noop",
+				Path:    "noop.md",
 			},
 		},
 	}

--- a/cannon.example.yml
+++ b/cannon.example.yml
@@ -1,36 +1,38 @@
 repos:
   - name: TouchBistro/touchbistro-node-boilerplate
-  - name: TouchBistro/ordering-deliveroo-service
+  - name: TouchBistro/ordering-service
     base: develop
 actions:
   - type: replaceLine
-    source: DB_USER=core
-    target: DB_USER=SA
+    searchText: DB_USER=SA
+    applyText: DB_USER=core
     path: .env.example
   - type: deleteLine
-    target: NODE_ENV=development
+    searchText: NODE_ENV=development
     path: .env.example
   - type: replaceText
-    source: LOGGER.debug
-    target: console.log
+    searchText: console.log
+    applyText: LOGGER.debug
     path: src/index.ts
   - type: appendText
-    source: _local
-    target: NODE_ENV=development
+    searchText: NODE_ENV=development
+    applyText: _local
     path: .env.example
   - type: deleteText
-    target: "import '@touchbistro/[a-z\\-]+'\n"
+    searchText: "import '@touchbistro/[a-z\\-]+'\n"
     path: src/index.ts
   - type: createFile
-    source: files/text.txt
-    path: text.txt
+    srcPath: files/text.txt
+    dstPath: text.txt
   - type: deleteFile
-    path: .env.example
+    dstPath: .env.example
   - type: replaceFile
-    source: files/.env.test
-    path: .env.compose
+    srcPath: files/.env.test
+    dstPath: .env.compose
   - type: createOrReplaceFile
-    source: files/.env.test
-    path: .env.test
+    srcPath: files/.env.test
+    dstPath: .env.test
   - type: runCommand
-    run: yarn
+    run: yarn install
+  - type: shellCommand
+    run: if [ ! -d data ]; then mkdir data; touch data/.gitkeep; fi


### PR DESCRIPTION
The config schema for all action types have been changed to make it way clearer. The current config is super confusing, this aims to make it better.

#### Text Actions
* `target` -> `searchText`
* `source` -> `applyText`

#### File Actions
* `source` -> `srcPath`
* `path` -> `dstPath`

#### Command Actions
* Added `type: shellCommand` to run a command in a shell. This replaces the `SHELL >>` prefix in `runCommand`.

### Additional Changes
* Added `--clean` flag which removes the cannon cache dir when cannon starts running.